### PR TITLE
eslint-plugin-react-hooks をアップデートする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -461,9 +461,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.4.0.tgz",
-      "integrity": "sha512-fMGlzztW/5hSQT0UBnlPwulao0uF8Kyp0Uv6PA81lzmcDz2LBtthkWQaE8Wz2F2kEe7mSRDgK8ABEFK1ipeDxw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.1.tgz",
+      "integrity": "sha512-i3dIrmZ+Ssrm0LrbbtuGcRf7EEpe1FaMuL8XnnpZO0X4tk3dZNzevWxD0/7nMAFa5yZQfNnYkfEP0MmwLvbdHw=="
     },
     "eslint-restricted-globals": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "eslint-plugin-react-hooks": "^1.4.0",
+    "eslint-plugin-react-hooks": "^1.5.1",
     "prettier": "^1.15.2"
   }
 }

--- a/react.js
+++ b/react.js
@@ -4,6 +4,7 @@ module.exports = {
     'react/jsx-filename-extension': 0,
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 2,
+    'react-hooks/exhaustive-deps': 2,
     'react/jsx-key': 2,
   },
 };


### PR DESCRIPTION
`react-hooks/exhaustive-deps`を有効にするのが目的。